### PR TITLE
if zp_status: does not always catch an unfilled zp_status

### DIFF
--- a/zipline/gens/brokers/ib_broker.py
+++ b/zipline/gens/brokers/ib_broker.py
@@ -829,14 +829,14 @@ class IBBroker(Broker):
                 open_order_state = self._tws.open_orders[ib_order_id]['state']
 
                 zp_status = self._ib_to_zp_status(open_order_state.m_status)
-                if zp_status:
-                    zp_order.status = zp_status
-                else:
+                if zp_status is None:
                     log.warning(
                         "Order-{order_id}: "
                         "unknown order status: {order_status}.".format(
                             order_id=ib_order_id,
                             order_status=open_order_state.m_status))
+                else:
+                    zp_order.status = zp_status
 
             if ib_order_id in self._tws.order_statuses:
                 order_status = self._tws.order_statuses[ib_order_id]


### PR DESCRIPTION
After hours of debugging I found that "if zp_status:" needed to be changed to if zp_status is None: as the first test did not always catch a filled zp_status. Reversed the order of the if statement off course